### PR TITLE
Fix UTF unicode decode errors trying to connect to a newer SAP server

### DIFF
--- a/pyrfc/_pyrfc.pyx
+++ b/pyrfc/_pyrfc.pyx
@@ -2052,7 +2052,7 @@ cdef wrapString(SAP_UC* uc, uclen=-1, rstrip=False):
         uclen = strlenU(uc)
     if uclen == 0:
         return ''
-    cdef unsigned utf8_size = uclen * 3 + 1
+    cdef unsigned utf8_size = uclen * 5 + 1
     cdef char *utf8 = <char*> malloc(utf8_size)
     utf8[0] = '\0'
     cdef unsigned result_len = 0
@@ -2060,10 +2060,11 @@ cdef wrapString(SAP_UC* uc, uclen=-1, rstrip=False):
     if rc != RFC_OK:
         # raise wrapError(&errorInfo)
         raise RFCError('wrapString uclen: %u utf8_size: %u' % (uclen, utf8_size))
+    utf8[result_len] = '\0'
     try:
         if rstrip:
-            return utf8.rstrip().decode('UTF-8')
+            return utf8[:result_len].rstrip().decode('UTF-8')
         else:
-            return utf8.decode('UTF-8')
+            return utf8[:result_len].decode('UTF-8')
     finally:
         free(utf8)


### PR DESCRIPTION
This brings a fix from the mainline for utf8 string handling - I was getting a lot of decoding errors connecting to the SDx SAP server without this patch. I think it may be something that changed in a newer version of SAP that exposed the bug in PyRFC.